### PR TITLE
fixed white bachground on challenges/id

### DIFF
--- a/frontend/src/app/modules/challenges/online-editor-page/online-editor-page.component.ts
+++ b/frontend/src/app/modules/challenges/online-editor-page/online-editor-page.component.ts
@@ -124,7 +124,7 @@ export class OnlineEditorPageComponent extends BaseComponent implements OnInit {
     private getInitialTestByChallengeVersionId(id: number) {
         const selectedVersion = this.challenge.versions.find((version) => version.id === id);
 
-        return (selectedVersion && selectedVersion.tests.length)
+        return (selectedVersion && selectedVersion.tests?.length)
             ? selectedVersion.tests[0].code
             : 'No tests available';
     }


### PR DESCRIPTION
![image](https://github.com/BinaryStudioAcademy/bsa-2023-leetwars/assets/68563967/08813641-0cdf-4262-ac13-f1e17b0dd1b2)

https://trello.com/c/MXo4rhiT/155-bug53-challenges-id-page-the-code-editor-block-has-a-white-background