### PR TITLE
Changed styles for markdown and tooltip

### DIFF
--- a/frontend/src/app/modules/challenges/challenge-creation/challenge-creation.component.sass
+++ b/frontend/src/app/modules/challenges/challenge-creation/challenge-creation.component.sass
@@ -5,7 +5,7 @@
     margin: 40px 130px
     background-color: $deep-dark-grey
     border-radius: 32px
-    min-height: 100%
+    height: 100%
 
 .buttons
     justify-content: flex-end
@@ -104,3 +104,21 @@
             width: 100%
         & app-challenges-dropdown-select
             width: 80%
+            
+.step-container
+    height: 85%
+
+:host ::ng-deep app-editor-question
+    height: 100%
+
+:host ::ng-deep .content-wrapper
+    height: 100%
+
+    .markdown-wrapper
+        height: 60%   
+
+    .md-editor
+        height: 100%
+
+    #markdown-editor
+        height: 100%

--- a/frontend/src/app/modules/challenges/challenges-test-page/challenges-test-page.component.html
+++ b/frontend/src/app/modules/challenges/challenges-test-page/challenges-test-page.component.html
@@ -11,10 +11,6 @@
                     [customClass]="getTabClass(tab)">
                 </tab>
             </tabset>
-            <div class="tab-help" ngbTooltip="Help message" placement="right">
-                <fa-icon [icon]="'question-circle'"></fa-icon>
-                <div class="tab-text">Help</div>
-            </div>
         </div>
         <button class="maximize-btn" (click)="toggleMaximize(editorContainer)">
             <fa-icon [icon]="isMaximized ? ['fas', 'compress'] : ['fas', 'maximize']"></fa-icon>

--- a/frontend/src/app/modules/challenges/challenges-test-page/challenges-test-page.component.html
+++ b/frontend/src/app/modules/challenges/challenges-test-page/challenges-test-page.component.html
@@ -11,8 +11,8 @@
                     [customClass]="getTabClass(tab)">
                 </tab>
             </tabset>
-            <div class="tab-help">
-                <fa-icon [icon]="'question-circle'" ngbTooltip="Help message" placement="top"></fa-icon>
+            <div class="tab-help" ngbTooltip="Help message" placement="right">
+                <fa-icon [icon]="'question-circle'"></fa-icon>
                 <div class="tab-text">Help</div>
             </div>
         </div>

--- a/frontend/src/app/modules/challenges/challenges-test-page/challenges-test-page.component.sass
+++ b/frontend/src/app/modules/challenges/challenges-test-page/challenges-test-page.component.sass
@@ -61,21 +61,3 @@
     @media screen and (max-width: $small-challenge)
         align-self: flex-end
 
-.tab-help
-    width: 46px
-    font-size: 13px
-    line-height: 40px
-    padding: 0px 22.09px 0px 22.39px
-    display: flex
-    justify-content: center
-    align-items: center
-    gap: 5px
-    margin-left: 20px
-    color: $transient-grey
-    @media screen and (max-width: $small-challenge)
-        margin: 0 0 10px 0
-        width: 100%
-
-.tab-help fa-icon
-    font-size: 12px
-    color: $transient-grey

--- a/frontend/src/app/modules/challenges/editor-question/editor-question.component.html
+++ b/frontend/src/app/modules/challenges/editor-question/editor-question.component.html
@@ -99,13 +99,9 @@
         <div class="tab" [class.tab-active]="selectedTab === TabType.Description" (click)="editMarkDown()">
             <span>Description</span>
         </div>
-        <div class="tab d-flex" [class.tab-active]="selectedTab === TabType.Preview" (click)="previewMarkDown()">
+        <div class="tab" [class.tab-active]="selectedTab === TabType.Preview" (click)="previewMarkDown()">
             <fa-icon [icon]="'eye'"></fa-icon>
             <span>Preview</span>
-        </div>
-        <div class="tab d-flex" [class.tab-active]="selectedTab === TabType.Help" (click)="submitQuestion()">
-            <fa-icon [icon]="'circle-question'"></fa-icon>
-            <span>Help</span>
         </div>
     </div>
     <div

--- a/frontend/src/app/modules/challenges/editor-question/editor-question.component.html
+++ b/frontend/src/app/modules/challenges/editor-question/editor-question.component.html
@@ -113,7 +113,7 @@
         *ngIf="inputForm.controls.description.touched && inputForm.controls.description.invalid">
         {{ getErrorMessage('description') }}
     </div>
-    <div class="mt-12px">
+    <div class="markdown-wrapper mt-12px">
         <angular-markdown-editor
             [textareaId]="'markdown-editor'"
             [name]="'markdownText'"

--- a/frontend/src/app/modules/challenges/editor-question/editor-question.component.sass
+++ b/frontend/src/app/modules/challenges/editor-question/editor-question.component.sass
@@ -97,7 +97,7 @@
   color: $white
   padding: 12px
   width: 100%
-  max-height: 260px
+  
 
 @media (max-width: $large)
   .input-wrapper

--- a/frontend/src/app/modules/challenges/editor-question/editor-question.component.sass
+++ b/frontend/src/app/modules/challenges/editor-question/editor-question.component.sass
@@ -56,7 +56,7 @@
 
 .tabs-list
   background-color: $double-weak-white
-  max-width: 340px
+  max-width: 240px
   border-radius: 8px
   overflow: hidden
 
@@ -64,7 +64,6 @@
   font-size: 14px
   padding: 12px 24px
   cursor: pointer
-  gap: 0.25em
   &:hover, &-active
     background-color: $delicate-lavender
 

--- a/frontend/src/app/modules/challenges/editor-question/editor-question.component.ts
+++ b/frontend/src/app/modules/challenges/editor-question/editor-question.component.ts
@@ -100,10 +100,6 @@ export class EditorQuestionComponent implements OnInit, OnChanges {
         this.bsEditorInstance.showPreview();
     }
 
-    submitQuestion() {
-        this.selectedTab = TabType.Help;
-    }
-
     onNameChange(value: string) {
         this.challenge.title = value;
 

--- a/frontend/src/app/modules/challenges/solution-page/solution-page.component.html
+++ b/frontend/src/app/modules/challenges/solution-page/solution-page.component.html
@@ -10,10 +10,6 @@
                 [customClass]="getTabClass(tab)">
             </tab>
         </tabset>
-        <div class="tab-help">
-            <fa-icon [icon]="'question-circle'" ngbTooltip="Help message" placement="top"></fa-icon>
-            <div class="tab-text">Help</div>
-        </div>
     </div>
     <div class="editor">
         <app-code-editor

--- a/frontend/src/app/modules/challenges/solution-page/solution-page.component.sass
+++ b/frontend/src/app/modules/challenges/solution-page/solution-page.component.sass
@@ -37,26 +37,6 @@
 .editor
     margin-top: 10px
 
-.tab-help
-  width: 46px
-  font-size: 13px
-  line-height: 40px
-  padding: 0px 22.09px 0px 22.39px
-  display: flex
-  justify-content: center
-  align-items: center
-  gap: 5px
-  margin-left: 20px
-  color: $transient-grey
-  @media screen and (max-width: $small-challenge)
-    margin: 0 0 10px 0
-    width: 100%
-
-.tab-help fa-icon
-  font-size: 12px
-  color: $transient-grey
-
-
 @media (max-width: $small-challenge)
   .tabs-container
     flex-direction: column

--- a/frontend/src/app/shared/enums/tab-type.ts
+++ b/frontend/src/app/shared/enums/tab-type.ts
@@ -1,5 +1,4 @@
 export enum TabType {
     Description = 'Description',
     Preview = 'Preview',
-    Help = 'Help',
 }


### PR DESCRIPTION
https://trello.com/c/nwofRFSj/213-bug87-create-challenge-test-cases-page-the-tooltip-message-goes-beyond-screen-visibility-in-full-screen
https://trello.com/c/hWjfjmpU/272-bug123-create-challenge-page-not-to-the-end-of-the-markdown-container
![Screenshot 2023-09-29 182756](https://github.com/BinaryStudioAcademy/bsa-2023-leetwars/assets/113329862/828e74b9-d1a6-4723-b046-a1da1584f592)
![Screenshot 2023-09-29 183115](https://github.com/BinaryStudioAcademy/bsa-2023-leetwars/assets/113329862/37882589-e5da-4e47-908d-30485c83f87e)
![Screenshot 2023-09-29 184028](https://github.com/BinaryStudioAcademy/bsa-2023-leetwars/assets/113329862/fdc4e51d-2cb6-4b33-a369-919e8c75337b)
